### PR TITLE
Update framelesswindow.cpp

### DIFF
--- a/src/framelesswindow.cpp
+++ b/src/framelesswindow.cpp
@@ -199,7 +199,7 @@ void FramelessWindow::setTitleBarMode(TitleMode flag){
             break;
         case FullTitle:
             ui->appTool->setVisible(true);
-            ui->rollBtn.setVisible(true);
+            ui->rollBtn->setVisible(true);
             ui->minBtn->setVisible(true);
             ui->maxBtn->setVisible(true);
             ui->closeBtn->setVisible(true);


### PR DESCRIPTION
On line 202:
ui->rollBtn.setVisible(true)  
CHANGED TO:
 ui->rollBtn->setVisible(true) 

because in Qt when working with pointers to objects created by Designer UI files, you should use the -> operator to access their members.